### PR TITLE
Feature/aave v2

### DIFF
--- a/contracts/callManagers/LendingManager/LendingLogicAave.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicAave.sol
@@ -2,12 +2,19 @@
 pragma experimental ABIEncoderV2;
 pragma solidity ^0.7.1;
 
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../interfaces/ILendingLogic.sol";
 import "../../interfaces/IAToken.sol";
 import "../../interfaces/IAaveLendingPool.sol";
 
+contract AToken is IAToken {
+    address public underlyingAssetAddress;
+    function redeem(uint256 _amount) external override {}
+}
+
 contract LendingLogicAave is ILendingLogic {
+    using SafeMath for uint256;
 
     IAaveLendingPool public lendingPool;
     uint16 public referralCode;
@@ -16,6 +23,33 @@ contract LendingLogicAave is ILendingLogic {
         require(_lendingPool != address(0), "LENDING_POOL_INVALID");
         lendingPool = IAaveLendingPool(_lendingPool);
         referralCode = _referralCode;
+    }
+
+    function getAPRFromWrapped(address _token) external view override returns(uint256) {
+        address underlying = AToken(_token).underlyingAssetAddress();
+        return getAPRFromUnderlying(underlying);
+    }
+
+    function getAPRFromUnderlying(address _token) public view override returns(uint256) {
+        address _lendingPool = address(lendingPool);
+        uint256[5] memory ret;
+
+        // https://ethereum.stackexchange.com/questions/84597/ilendingpool-getreservedata-function-gives-yulexception-stack-too-deep-when-com
+        bytes memory data = abi.encodeWithSelector(bytes4(keccak256("getReserveData(address)")), _token);
+        assembly {
+            let success := staticcall(
+                gas(),         // gas remaining
+                _lendingPool,  // destination address
+                add(data, 32), // input buffer (starts after the first 32 bytes in the `data` array)
+                mload(data),   // input length (loaded from the first 32 bytes in the `data` array)
+                ret,           // output buffer
+                64             // output length
+            )
+            if iszero(success) {
+                revert(0, 0)
+            }
+        }
+        return ret[4].div(1000000000);
     }
 
     function lend(address _underlying, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
@@ -40,13 +74,14 @@ contract LendingLogicAave is ILendingLogic {
 
         return(targets, data);
     }
+
     function unlend(address _wrapped, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
         targets = new address[](1);
         data = new bytes[](1);
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(IAToken.redeem.selector, _amount);
-        
+
         return(targets, data);
     }
 

--- a/contracts/callManagers/LendingManager/LendingLogicAave.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicAave.sol
@@ -50,4 +50,12 @@ contract LendingLogicAave is ILendingLogic {
         return(targets, data);
     }
 
+    function exchangeRate(address) external pure override returns(uint256) {
+        return 10**18;
+    }
+
+    function exchangeRateView(address) external pure override returns(uint256) {
+        return 10**18;
+    }
+
 }

--- a/contracts/callManagers/LendingManager/LendingLogicAave.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicAave.sol
@@ -43,7 +43,7 @@ contract LendingLogicAave is ILendingLogic {
                 add(data, 32), // input buffer (starts after the first 32 bytes in the `data` array)
                 mload(data),   // input length (loaded from the first 32 bytes in the `data` array)
                 ret,           // output buffer
-                64             // output length
+                160             // output length
             )
             if iszero(success) {
                 revert(0, 0)

--- a/contracts/callManagers/LendingManager/LendingLogicAaveV2.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicAaveV2.sol
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: MIT
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.1;
+
+import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "../../interfaces/ILendingLogic.sol";
+import "../../interfaces/IATokenV2.sol";
+import "../../interfaces/IAaveLendingPoolV2.sol";
+
+contract ATokenV2 is IATokenV2 {
+    address public UNDERLYING_ASSET_ADDRESS;
+}
+
+contract LendingLogicAaveV2 is ILendingLogic {
+    using SafeMath for uint128;
+
+    IAaveLendingPoolV2 public lendingPool;
+    uint16 public referralCode;
+    address public tokenHolder;
+
+    constructor(address _lendingPool, uint16 _referralCode, address _tokenHolder) {
+        require(_lendingPool != address(0), "LENDING_POOL_INVALID");
+        lendingPool = IAaveLendingPoolV2(_lendingPool);
+        referralCode = _referralCode;
+        tokenHolder = _tokenHolder;
+    }
+
+    function getAPRFromWrapped(address _token) external view override returns(uint256) {
+        address underlying = ATokenV2(_token).UNDERLYING_ASSET_ADDRESS();
+        return getAPRFromUnderlying(underlying);
+    }
+
+    function getAPRFromUnderlying(address _token) public view override returns(uint256) {
+        DataTypes.ReserveData memory reserveData = lendingPool.getReserveData(_token);
+        return reserveData.currentLiquidityRate.div(1000000000);
+    }
+
+    function lend(address _underlying, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
+        IERC20 underlying = IERC20(_underlying);
+
+        targets = new address[](3);
+        data = new bytes[](3);
+
+        // zero out approval to be sure
+        targets[0] = _underlying;
+        data[0] = abi.encodeWithSelector(underlying.approve.selector, address(lendingPool), 0);
+
+        // Set approval
+        targets[1] = _underlying;
+        data[1] = abi.encodeWithSelector(underlying.approve.selector, address(lendingPool), _amount);
+
+        // Deposit into Aave
+        targets[2] = address(lendingPool);
+        data[2] =  abi.encodeWithSelector(lendingPool.deposit.selector, _underlying, _amount, tokenHolder, referralCode);
+
+        return(targets, data);
+    }
+
+    function unlend(address _wrapped, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
+        ATokenV2 wrapped = ATokenV2(_wrapped);
+
+        targets = new address[](1);
+        data = new bytes[](1);
+
+        targets[0] = address(lendingPool);
+        data[0] = abi.encodeWithSelector(
+            lendingPool.withdraw.selector,
+            wrapped.UNDERLYING_ASSET_ADDRESS(),
+            _amount,
+            tokenHolder
+        );
+
+        return(targets, data);
+    }
+
+    function exchangeRate(address) external pure override returns(uint256) {
+        return 10**18;
+    }
+
+    function exchangeRateView(address) external pure override returns(uint256) {
+        return 10**18;
+    }
+
+}

--- a/contracts/callManagers/LendingManager/LendingLogicCompound.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicCompound.sol
@@ -2,20 +2,40 @@
 pragma experimental ABIEncoderV2;
 pragma solidity ^0.7.1;
 
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/math/SafeMath.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../interfaces/ILendingLogic.sol";
 import "./LendingRegistry.sol";
 import "../../interfaces/ICToken.sol";
 
-contract LendingLogicCompound is ILendingLogic {
+contract LendingLogicCompound is Ownable, ILendingLogic {
+    using SafeMath for uint256;
 
     LendingRegistry public lendingRegistry;
     bytes32 public immutable protocolKey;
+    uint256 public blocksPerYear;
 
     constructor(address _lendingRegistry, bytes32 _protocolKey) {
         require(_lendingRegistry != address(0), "INVALID_LENDING_REGISTRY");
         lendingRegistry = LendingRegistry(_lendingRegistry);
         protocolKey = _protocolKey;
+    }
+
+    function setBlocksPerYear(uint256 _blocks) external onlyOwner {
+        // calculated by taking APY onn compound.finance  / dividing by supplyrate per block
+        // this is apparently the amount of blocks compound expects to be minted this year
+        // 2145683;
+        blocksPerYear = _blocks;
+    }
+
+    function getAPRFromWrapped(address _token) public view override returns(uint256) {
+        return ICToken(_token).supplyRatePerBlock().mul(blocksPerYear);
+    }
+
+    function getAPRFromUnderlying(address _token) external view override returns(uint256) {
+        address cToken = lendingRegistry.underlyingToProtocolWrapped(_token, protocolKey);
+        return getAPRFromWrapped(cToken);
     }
 
     function lend(address _underlying, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
@@ -48,7 +68,7 @@ contract LendingLogicCompound is ILendingLogic {
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(ICToken.redeem.selector, _amount);
-        
+
         return(targets, data);
     }
 

--- a/contracts/callManagers/LendingManager/LendingLogicCompound.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicCompound.sol
@@ -42,6 +42,7 @@ contract LendingLogicCompound is ILendingLogic {
 
         return(targets, data);
     }
+    
     function unlend(address _wrapped, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
         targets = new address[](1);
         data = new bytes[](1);
@@ -50,6 +51,14 @@ contract LendingLogicCompound is ILendingLogic {
         data[0] = abi.encodeWithSelector(ICToken.redeem.selector, _amount);
         
         return(targets, data);
+    }
+    
+    function exchangeRate(address _wrapped) external override returns(uint256) {
+        return ICToken(_wrapped).exchangeRateCurrent();
+    }
+
+    function exchangeRateView(address _wrapped) external view override returns(uint256) {
+        return ICToken(_wrapped).exchangeRateStored();
     }
 
 }

--- a/contracts/callManagers/LendingManager/LendingLogicCompound.sol
+++ b/contracts/callManagers/LendingManager/LendingLogicCompound.sol
@@ -42,17 +42,17 @@ contract LendingLogicCompound is ILendingLogic {
 
         return(targets, data);
     }
-    
+
     function unlend(address _wrapped, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
         targets = new address[](1);
         data = new bytes[](1);
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(ICToken.redeem.selector, _amount);
-        
+
         return(targets, data);
     }
-    
+
     function exchangeRate(address _wrapped) external override returns(uint256) {
         return ICToken(_wrapped).exchangeRateCurrent();
     }

--- a/contracts/callManagers/LendingManager/StakeSushi.sol
+++ b/contracts/callManagers/LendingManager/StakeSushi.sol
@@ -18,6 +18,14 @@ contract StakingLogicSushi is ILendingLogic {
         protocolKey = _protocolKey;
     }
 
+    function getAPRFromWrapped(address _token) public view override returns(uint256) {
+        return uint256(-1);
+    }
+
+    function getAPRFromUnderlying(address _token) external view override returns(uint256) {
+        return uint256(-1);
+    }
+
     function lend(address _underlying, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
         IERC20 underlying = IERC20(_underlying);
 
@@ -48,7 +56,7 @@ contract StakingLogicSushi is ILendingLogic {
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(IXSushi.leave.selector, _amount);
-        
+
         return(targets, data);
     }
 

--- a/contracts/callManagers/LendingManager/StakeSushi.sol
+++ b/contracts/callManagers/LendingManager/StakeSushi.sol
@@ -52,4 +52,19 @@ contract StakingLogicSushi is ILendingLogic {
         return(targets, data);
     }
 
+    function exchangeRate(address _wrapped) external view override returns(uint256) {
+        return _exchangeRate(_wrapped);
+    }
+
+    function exchangeRateView(address _wrapped) external view override returns(uint256) {
+        return _exchangeRate(_wrapped);
+    }
+
+    function _exchangeRate(address _wrapped) internal view returns(uint256) {
+        IERC20 xToken = IERC20(_wrapped);
+        IERC20 token = IERC20(lendingRegistry.wrappedToUnderlying(_wrapped));
+
+        return token.balanceOf(_wrapped) * 10**18 / xToken.totalSupply();
+    }
+
 }

--- a/contracts/callManagers/LendingManager/StakeSushi.sol
+++ b/contracts/callManagers/LendingManager/StakeSushi.sol
@@ -48,11 +48,11 @@ contract StakingLogicSushi is ILendingLogic {
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(IXSushi.leave.selector, _amount);
-        
+
         return(targets, data);
     }
 
-    function exchangeRate(address _wrapped) external view override returns(uint256) {
+    function exchangeRate(address _wrapped) external override returns(uint256) {
         return _exchangeRate(_wrapped);
     }
 
@@ -63,7 +63,6 @@ contract StakingLogicSushi is ILendingLogic {
     function _exchangeRate(address _wrapped) internal view returns(uint256) {
         IERC20 xToken = IERC20(_wrapped);
         IERC20 token = IERC20(lendingRegistry.wrappedToUnderlying(_wrapped));
-
         return token.balanceOf(_wrapped) * 10**18 / xToken.totalSupply();
     }
 

--- a/contracts/callManagers/LendingManager/StakeSushi.sol
+++ b/contracts/callManagers/LendingManager/StakeSushi.sol
@@ -52,7 +52,7 @@ contract StakingLogicSushi is ILendingLogic {
         return(targets, data);
     }
 
-    function exchangeRate(address _wrapped) external override returns(uint256) {
+    function exchangeRate(address _wrapped) external view override returns(uint256) {
         return _exchangeRate(_wrapped);
     }
 

--- a/contracts/callManagers/LendingManager/StakingLogicYGov.sol
+++ b/contracts/callManagers/LendingManager/StakingLogicYGov.sol
@@ -48,8 +48,16 @@ contract StakingLogicYGov is ILendingLogic {
 
         targets[0] = _wrapped;
         data[0] = abi.encodeWithSelector(IYVault.withdraw.selector, _amount);
-        
+
         return(targets, data);
+    }
+
+    function getAPRFromUnderlying(address _token) external view override returns(uint256) {
+        return uint256(-1);
+    }
+
+    function getAPRFromWrapped(address _token) external view override returns(uint256) {
+        return uint256(-1);
     }
 
 }

--- a/contracts/callManagers/LendingManager/StakingLogicYGov.sol
+++ b/contracts/callManagers/LendingManager/StakingLogicYGov.sol
@@ -52,4 +52,12 @@ contract StakingLogicYGov is ILendingLogic {
         return(targets, data);
     }
 
+    function exchangeRate(address _wrapped) external view override returns(uint256) {
+        return IYVault(_wrapped).getPricePerFullShare();
+    }
+
+    function exchangeRateView(address _wrapped) external view override returns(uint256) {
+        return IYVault(_wrapped).getPricePerFullShare();
+    }
+
 }

--- a/contracts/interfaces/IATokenV2.sol
+++ b/contracts/interfaces/IATokenV2.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.1;
+
+interface IATokenV2 {
+
+}
+

--- a/contracts/interfaces/IAaveLendingPool.sol
+++ b/contracts/interfaces/IAaveLendingPool.sol
@@ -5,4 +5,22 @@ pragma solidity ^0.7.1;
 interface IAaveLendingPool {
     function deposit(address _reserve, uint256 _amount, uint16 _referralCode) external;
     function core() external view returns(address);
+    function getReserveData(address _reserve)
+        external
+        view
+        returns (
+            uint256 totalLiquidity,
+            uint256 availableLiquidity,
+            uint256 totalBorrowsStable,
+            uint256 totalBorrowsVariable,
+            uint256 liquidityRate,
+            uint256 variableBorrowRate,
+            uint256 stableBorrowRate,
+            uint256 averageStableBorrowRate,
+            uint256 utilizationRate,
+            uint256 liquidityIndex,
+            uint256 variableBorrowIndex,
+            address aTokenAddress,
+            uint40 lastUpdateTimestamp
+        );
 }

--- a/contracts/interfaces/IAaveLendingPoolV2.sol
+++ b/contracts/interfaces/IAaveLendingPoolV2.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.1;
+
+library DataTypes {
+  // refer to the whitepaper, section 1.1 basic concepts for a formal description of these properties.
+  struct ReserveData {
+    //stores the reserve configuration
+    ReserveConfigurationMap configuration;
+    //the liquidity index. Expressed in ray
+    uint128 liquidityIndex;
+    //variable borrow index. Expressed in ray
+    uint128 variableBorrowIndex;
+    //the current supply rate. Expressed in ray
+    uint128 currentLiquidityRate;
+    //the current variable borrow rate. Expressed in ray
+    uint128 currentVariableBorrowRate;
+    //the current stable borrow rate. Expressed in ray
+    uint128 currentStableBorrowRate;
+    uint40 lastUpdateTimestamp;
+    //tokens addresses
+    address aTokenAddress;
+    address stableDebtTokenAddress;
+    address variableDebtTokenAddress;
+    //address of the interest rate strategy
+    address interestRateStrategyAddress;
+    //the id of the reserve. Represents the position in the list of the active reserves
+    uint8 id;
+  }
+
+  struct ReserveConfigurationMap {
+    //bit 0-15: LTV
+    //bit 16-31: Liq. threshold
+    //bit 32-47: Liq. bonus
+    //bit 48-55: Decimals
+    //bit 56: Reserve is active
+    //bit 57: reserve is frozen
+    //bit 58: borrowing is enabled
+    //bit 59: stable rate borrowing enabled
+    //bit 60-63: reserved
+    //bit 64-79: reserve factor
+    uint256 data;
+  }
+
+  struct UserConfigurationMap {
+    uint256 data;
+  }
+
+  enum InterestRateMode {NONE, STABLE, VARIABLE}
+}
+
+interface IAaveLendingPoolV2 {
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 referralCode
+    ) external;
+
+    function withdraw(
+        address asset,
+        uint256 amount,
+        address to
+    ) external;
+
+    function getReserveData(address asset)
+        external
+        view
+        returns (DataTypes.ReserveData memory);
+}

--- a/contracts/interfaces/ICToken.sol
+++ b/contracts/interfaces/ICToken.sol
@@ -5,4 +5,6 @@ pragma solidity ^0.7.1;
 interface ICToken {
     function mint(uint _mintAmount) external returns (uint256);
     function redeem(uint _redeemTokens) external returns (uint256);
+    function exchangeRateCurrent() external returns (uint256);
+    function exchangeRateStored() external view returns(uint256);
 }

--- a/contracts/interfaces/ICToken.sol
+++ b/contracts/interfaces/ICToken.sol
@@ -5,4 +5,5 @@ pragma solidity ^0.7.1;
 interface ICToken {
     function mint(uint _mintAmount) external returns (uint256);
     function redeem(uint _redeemTokens) external returns (uint256);
+    function supplyRatePerBlock() external view returns (uint256);
 }

--- a/contracts/interfaces/ILendingLogic.sol
+++ b/contracts/interfaces/ILendingLogic.sol
@@ -20,4 +20,18 @@ interface ILendingLogic {
         @return data Calldata of the calls
     */
     function unlend(address _wrapped, uint256 _amount) external view returns(address[] memory targets, bytes[] memory data);
+
+    /**
+        @notice Get the underlying wrapped exchange rate
+        @param _wrapped Address of the wrapped token
+        @return The exchange rate
+    */
+    function exchangeRate(address _wrapped) external returns(uint256);
+
+    /**
+        @notice Get the underlying wrapped exchange rate in a view (non state changing) way
+        @param _wrapped Address of the wrapped token
+        @return The exchange rate
+    */
+    function exchangeRateView(address _wrapped) external view returns(uint256);
 }

--- a/contracts/interfaces/ILendingLogic.sol
+++ b/contracts/interfaces/ILendingLogic.sol
@@ -4,6 +4,20 @@ pragma solidity ^0.7.1;
 
 interface ILendingLogic {
     /**
+        @notice Get the APR based on underlying token.
+        @param _token Address of the underlying token
+        @return Interest with 18 decimals
+    */
+    function getAPRFromUnderlying(address _token) external view returns(uint256);
+
+    /**
+        @notice Get the APR based on wrapped token.
+        @param _token Address of the wrapped token
+        @return Interest with 18 decimals
+    */
+    function getAPRFromWrapped(address _token) external view returns(uint256);
+
+    /**
         @notice Get the calls needed to lend.
         @param _underlying Address of the underlying token
         @param _amount Amount of the underlying token
@@ -11,7 +25,7 @@ interface ILendingLogic {
         @return data Calldata of the calls
     */
     function lend(address _underlying, uint256 _amount) external view returns(address[] memory targets, bytes[] memory data);
-    
+
     /**
         @notice Get the calls needed to unlend
         @param _wrapped Address of the wrapped token

--- a/contracts/test/MockAToken.sol
+++ b/contracts/test/MockAToken.sol
@@ -8,16 +8,18 @@ import "./MockToken.sol";
 contract MockAToken is MockToken {
     IERC20 public token;
 
+    address public underlyingAssetAddress;
     bool public revertRedeem;
 
-    constructor(address _token) MockToken("MockAToken", "MATKN") public {
+    constructor(address _token) public MockToken("MockAToken", "MATKN") {
         token = IERC20(_token);
+        underlyingAssetAddress = _token;
     }
 
     function redeem(uint256 _amount) external {
         require(!revertRedeem, "Reverted");
 
-        if(_amount == uint256(-1)) {
+        if (_amount == uint256(-1)) {
             _amount = balanceOf(msg.sender);
         }
 

--- a/contracts/test/MockATokenV2.sol
+++ b/contracts/test/MockATokenV2.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.1;
+
+import "../interfaces/IAaveLendingPool.sol";
+import "./MockToken.sol";
+
+contract MockATokenV2 is MockToken {
+    IERC20 public token;
+
+    address public UNDERLYING_ASSET_ADDRESS;
+
+    constructor(address _token) public MockToken("MockATokenV2", "MATKNV2") {
+        token = IERC20(_token);
+        UNDERLYING_ASSET_ADDRESS = _token;
+    }
+
+}

--- a/contracts/test/MockAaveLendingPool.sol
+++ b/contracts/test/MockAaveLendingPool.sol
@@ -20,7 +20,7 @@ contract MockAaveLendingPool is IAaveLendingPool {
         require(!revertDeposit, "Deposited revert");
         require(token.transferFrom(msg.sender, address(aToken), _amount), "Transfer failed");
         aToken.mint(_amount, msg.sender);
-    } 
+    }
 
     function setRevertDeposit(bool _doRevert) external {
         revertDeposit = _doRevert;
@@ -29,4 +29,40 @@ contract MockAaveLendingPool is IAaveLendingPool {
     function core() external view override returns(address) {
         return address(this);
     }
+
+    function getReserveData(address _reserve)
+        external
+        override
+        view
+        returns (
+            uint256 totalLiquidity,
+            uint256 availableLiquidity,
+            uint256 totalBorrowsStable,
+            uint256 totalBorrowsVariable,
+            uint256 liquidityRate,
+            uint256 variableBorrowRate,
+            uint256 stableBorrowRate,
+            uint256 averageStableBorrowRate,
+            uint256 utilizationRate,
+            uint256 liquidityIndex,
+            uint256 variableBorrowIndex,
+            address aTokenAddress,
+            uint40 lastUpdateTimestamp
+        ) {
+            return(
+                0,
+                0,
+                0,
+                0,
+                10000000000000000000000000, //1%
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                address(0),
+                0
+            );
+        }
 }

--- a/contracts/test/MockAaveLendingPoolV2.sol
+++ b/contracts/test/MockAaveLendingPoolV2.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.7.1;
 import "../interfaces/IAaveLendingPoolV2.sol";
 import "./MockToken.sol";
 
-contract MockAaveLendingPool is IAaveLendingPoolV2 {
+contract MockAaveLendingPoolV2 is IAaveLendingPoolV2 {
     IERC20 public token;
     MockToken public aToken;
 
@@ -24,7 +24,7 @@ contract MockAaveLendingPool is IAaveLendingPoolV2 {
         uint16 _referralCode
     ) external override {
         require(!revertDeposit, "Deposited revert");
-        require(token.transferFrom(msg.sender, address(aToken), _amount), "Transfer failed");
+        require(token.transferFrom(msg.sender, address(this), _amount), "Transfer failed");
         aToken.mint(_amount, msg.sender);
     }
 

--- a/contracts/test/MockAaveLendingPoolV2.sol
+++ b/contracts/test/MockAaveLendingPoolV2.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma experimental ABIEncoderV2;
+pragma solidity ^0.7.1;
+
+import "../interfaces/IAaveLendingPoolV2.sol";
+import "./MockToken.sol";
+
+contract MockAaveLendingPool is IAaveLendingPoolV2 {
+    IERC20 public token;
+    MockToken public aToken;
+
+    bool public revertDeposit;
+    bool public revertWithdraw;
+
+    constructor(address _token, address _aToken) public {
+        token = IERC20(_token);
+        aToken = MockToken(_aToken);
+    }
+
+    function deposit(
+        address _asset,
+        uint256 _amount,
+        address _onBehalfOf,
+        uint16 _referralCode
+    ) external override {
+        require(!revertDeposit, "Deposited revert");
+        require(token.transferFrom(msg.sender, address(aToken), _amount), "Transfer failed");
+        aToken.mint(_amount, msg.sender);
+    }
+
+    function withdraw(
+        address _asset,
+        uint256 _amount,
+        address _to
+    ) external override {
+        require(!revertWithdraw, "Reverted");
+
+        if (_amount == uint256(-1)) {
+            _amount = aToken.balanceOf(msg.sender);
+        }
+
+        aToken.burn(_amount, msg.sender);
+        require(token.transfer(msg.sender, _amount), "Transfer failed");
+    }
+
+    function getReserveData(address asset)
+        external
+        view
+        override
+        returns (DataTypes.ReserveData memory) {
+        return DataTypes.ReserveData({
+            configuration: DataTypes.ReserveConfigurationMap(0),
+            liquidityIndex: 0,
+            variableBorrowIndex: 0,
+            currentLiquidityRate: 10000000000000000000000000, //1%
+            currentVariableBorrowRate: 0,
+            currentStableBorrowRate: 0,
+            lastUpdateTimestamp: 0,
+            aTokenAddress: address(0),
+            stableDebtTokenAddress: address(0),
+            variableDebtTokenAddress: address(0),
+            interestRateStrategyAddress: address(0),
+            id: 0
+        });
+    }
+
+
+
+    function setRevertDeposit(bool _doRevert) external {
+        revertDeposit = _doRevert;
+    }
+    function setRevertWithdraw(bool _doRevert) external {
+        revertWithdraw = _doRevert;
+    }
+}

--- a/contracts/test/MockCToken.sol
+++ b/contracts/test/MockCToken.sol
@@ -3,20 +3,22 @@ pragma experimental ABIEncoderV2;
 pragma solidity ^0.7.1;
 
 import "./MockToken.sol";
+import "../interfaces/ICToken.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
 
-contract MockCToken is MockToken {
+contract MockCToken is MockToken, ICToken {
     using SafeMath for uint256;
     uint256 public exchangeRate = 1 ether / 5;
     MockToken public underlying;
+    uint256 someValue;
 
     uint256 public errorCode;
     constructor(address _underlying) MockToken("cTOKEN", "cToken") public {
         underlying = MockToken(_underlying);
     }
 
-    function mint(uint256 _amount) external returns(uint256) {
+    function mint(uint256 _amount) external override returns(uint256) {
         require(underlying.transferFrom(msg.sender, address(this), _amount), "MockCToken.mint: transferFrom failed");
 
         uint256 mintAmount = _amount.mul(10**18).div(exchangeRate);
@@ -25,11 +27,7 @@ contract MockCToken is MockToken {
         return errorCode;
     }
 
-    function exchangeRateStored() external view returns(uint256) {
-        return exchangeRate;
-    }
-
-    function redeem(uint256 _amount) external returns(uint256) {
+    function redeem(uint256 _amount) external override returns(uint256) {
         _burn(msg.sender, _amount);
 
         uint256 underlyingAmount = _amount.mul(exchangeRate).div(10**18);
@@ -53,5 +51,18 @@ contract MockCToken is MockToken {
 
     function setErrorCode(uint256 _value) public {
         errorCode = _value;
+    }
+
+    
+    function exchangeRateCurrent() external override returns(uint256) {
+        // To make function state changing
+        someValue ++;
+        return exchangeRate;
+    }
+
+    function exchangeRateStored() external override view returns(uint256) {
+        // To make function non pure;
+        someValue;
+        return exchangeRate;
     }
 }

--- a/contracts/test/MockCToken.sol
+++ b/contracts/test/MockCToken.sol
@@ -9,7 +9,8 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 
 contract MockCToken is MockToken, ICToken {
     using SafeMath for uint256;
-    uint256 public exchangeRate = 1 ether / 5;
+    // representable value taken from cEth
+    uint256 public exchangeRate = 200000000000000000000000000;
     MockToken public underlying;
     uint256 someValue;
 
@@ -53,7 +54,6 @@ contract MockCToken is MockToken, ICToken {
         errorCode = _value;
     }
 
-    
     function exchangeRateCurrent() external override returns(uint256) {
         // To make function state changing
         someValue ++;

--- a/contracts/test/MockCToken.sol
+++ b/contracts/test/MockCToken.sol
@@ -54,4 +54,8 @@ contract MockCToken is MockToken {
     function setErrorCode(uint256 _value) public {
         errorCode = _value;
     }
+
+    function supplyRatePerBlock() external view returns (uint256) {
+        return 20000000000;
+    }
 }

--- a/contracts/test/MockCToken.sol
+++ b/contracts/test/MockCToken.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/math/SafeMath.sol";
 contract MockCToken is MockToken, ICToken {
     using SafeMath for uint256;
     // representable value taken from cEth
-    uint256 public exchangeRate = 200000000000000000000000000;
+    uint256 public exchangeRate = 1 ether / 5;
     MockToken public underlying;
     uint256 someValue;
 

--- a/contracts/test/MockLendingLogic.sol
+++ b/contracts/test/MockLendingLogic.sol
@@ -19,4 +19,12 @@ contract MockLendingLogic is ILendingLogic {
         targets[0] = _wrapped;
         data[0] = bytes(abi.encode(_amount));
     }
+
+    function exchangeRate(address) external pure override returns(uint256) {
+        return 10**18;
+    }
+
+    function exchangeRateView(address) external pure override returns(uint256) {
+        return 10**18;
+    }
 }

--- a/contracts/test/MockLendingLogic.sol
+++ b/contracts/test/MockLendingLogic.sol
@@ -5,6 +5,14 @@ pragma solidity ^0.7.1;
 import "../interfaces/ILendingLogic.sol";
 
 contract MockLendingLogic is ILendingLogic {
+    function getAPRFromWrapped(address _token) external view override returns(uint256) {
+        return uint256(2000000000000000000); // 2%
+    }
+
+    function getAPRFromUnderlying(address _token) public view override returns(uint256) {
+        return uint256(2000000000000000000); // 2%
+    }
+
     function lend(address _underlying, uint256 _amount) external view override returns(address[] memory targets, bytes[] memory data) {
         targets = new address[](1);
         data = new bytes[](1);

--- a/contracts/test/MockToken.sol
+++ b/contracts/test/MockToken.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.7.1;
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockToken is ERC20 {
+
     constructor(string memory _name, string memory _symbol)
         ERC20(_name, _symbol)
     {}

--- a/contracts/test/MockXSushi.sol
+++ b/contracts/test/MockXSushi.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.7.1;
 import "./MockToken.sol";
 import "@openzeppelin/contracts/math/SafeMath.sol";
 
-
 contract MockXSushi is MockToken {
     using SafeMath for uint256;
     uint256 public exchangeRate = 1 ether / 5;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@types/mocha": "^8.0.3",
     "@types/node": "^14.11.10",
     "chai-as-promised": "^7.1.1",
-    "diamond-2": "https://github.com/pie-dao/diamond-2.git/#ca94c95bbea06bbd961d525e06792bcec02c4462",
+    "diamond-2": "https://github.com/pie-dao/initialisable-diamond.git#ca94c95bbea06bbd961d525e06792bcec02c4462",
     "ethereum-waffle": "^3.1.1",
     "ethers": "^5.0.17",
     "solidity-coverage": "https://github.com/sc-forks/solidity-coverage",

--- a/test/LendingManager.ts
+++ b/test/LendingManager.ts
@@ -15,7 +15,7 @@ import DiamondArtifact from "../artifacts/Diamond.json";
 
 import TimeTraveler from "../utils/TimeTraveler";
 import { parseEther, formatBytes32String } from "ethers/lib/utils";
-import { 
+import {
     MockAToken,
     MockCToken,
     MockToken,
@@ -141,7 +141,7 @@ describe("LendingManager", function() {
         }
 
         await pieFactory.setDefaultController(account);
-        
+
         const diamondImplementation = await(deployContract(signers[0], DiamondArtifact)) as Diamond;
         diamondImplementation.initialize([], constants.AddressZero);
         pieFactory.setDiamondImplementation(diamondImplementation.address);
@@ -197,46 +197,46 @@ describe("LendingManager", function() {
         describe("Aave", async() => {
             it("Lending less than max should work", async() => {
                 const lendAmount = mintAmount.div(2);
-    
+
                 await lendingManager.lend(token.address, lendAmount, AAVE);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(2);
                 expect(tokens[0]).to.eq(token.address);
                 expect(tokens[1]).to.eq(aToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(lendAmount);
                 expect(aTokenBalance).to.eq(lendAmount);
             });
             it("Lending the max should work", async() => {
                 await lendingManager.lend(token.address, mintAmount, AAVE);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(1);
                 expect(tokens[0]).to.eq(aToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(0);
                 expect(aTokenBalance).to.eq(mintAmount);
             });
             it("Lending more than the max should lend the max", async() => {
                 await lendingManager.lend(token.address, mintAmount.add(parseEther("2")), AAVE);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(1);
                 expect(tokens[0]).to.eq(aToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(0);
                 expect(aTokenBalance).to.eq(mintAmount);
             });
@@ -245,44 +245,44 @@ describe("LendingManager", function() {
             it("Lending less than the max should work", async() => {
                 const lendAmount = mintAmount.div(2);
                 await lendingManager.lend(token.address, lendAmount, COMPOUND);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(2);
                 expect(tokens[0]).to.eq(token.address);
                 expect(tokens[1]).to.eq(cToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const cTokenBalance = await cToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(lendAmount);
                 expect(cTokenBalance).to.eq(lendAmount.mul(5));
             });
             it("Lending the max should work", async() => {
                 await lendingManager.lend(token.address, mintAmount, COMPOUND);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(1);
                 expect(tokens[0]).to.eq(cToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const cTokenBalance = await cToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(0);
                 expect(cTokenBalance).to.eq(mintAmount.mul(5));
             });
             it("Lending more than the max should lend the max", async() => {
                 await lendingManager.lend(token.address, mintAmount.add(parseEther("2")), COMPOUND);
-    
+
                 const tokens = await pie.getTokens();
-    
+
                 expect(tokens.length).to.eq(1);
                 expect(tokens[0]).to.eq(cToken.address);
-    
+
                 const tokenBalance = await token.balanceOf(pie.address);
                 const cTokenBalance = await cToken.balanceOf(pie.address);
-               
+
                 expect(tokenBalance).to.eq(0);
                 expect(cTokenBalance).to.eq(mintAmount.mul(5));
             });
@@ -298,7 +298,7 @@ describe("LendingManager", function() {
             it("Unlending less than the max should work", async() => {
                 const unlendAmount = mintAmount.div(2);
                 await lendingManager.unlend(aToken.address, unlendAmount);
-                
+
                 const tokens = await pie.getTokens();
 
                 expect(tokens.length).to.eq(2);
@@ -351,7 +351,7 @@ describe("LendingManager", function() {
             it("Unlending less than the max should work", async() => {
                 const unlendAmount = mintAmount.div(2).mul(5);
                 await lendingManager.unlend(cToken.address, unlendAmount);
-                
+
                 const tokens = await pie.getTokens();
 
                 expect(tokens.length).to.eq(2);
@@ -419,7 +419,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(bounceAmount);
                 expect(aTokenBalance).to.eq(mintAmount.div(2));
             });
@@ -434,7 +434,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(0);
                 expect(aTokenBalance).to.eq(mintAmount);
             });
@@ -449,7 +449,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(0);
                 expect(aTokenBalance).to.eq(mintAmount);
             });
@@ -473,7 +473,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(cTokenAmount);
                 expect(aTokenBalance).to.eq(bounceAmount);
             });
@@ -489,7 +489,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(cTokenAmount);
                 expect(aTokenBalance).to.eq(0);
             });
@@ -505,7 +505,7 @@ describe("LendingManager", function() {
 
                 const cTokenBalance = await cToken.balanceOf(pie.address);
                 const aTokenBalance = await aToken.balanceOf(pie.address);
-                
+
                 expect(cTokenBalance).to.eq(cTokenAmount);
                 expect(aTokenBalance).to.eq(0);
             });

--- a/test/lendingLogicAave.ts
+++ b/test/lendingLogicAave.ts
@@ -34,7 +34,7 @@ describe("LendingLogicAave", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const aTokenFactory = new MockATokenFactory(signers[0]);
 
@@ -96,7 +96,7 @@ describe("LendingLogicAave", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]
@@ -108,5 +108,17 @@ describe("LendingLogicAave", function() {
         expect(tokenBalance).to.eq(mintAmount);
         expect(aTokenBalance).to.eq(0);
     });
+
+    it("exchangeRate()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRate(aToken.address);
+        // 1 wrapped = 1
+        expect(exchangeRate).to.eq( ethers.BigNumber.from("10").pow(18))
+    })
+
+    it("exchangeRateView()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRateView(aToken.address);
+        // 1 wrapped == 1
+        expect(exchangeRate).to.eq( ethers.BigNumber.from("10").pow(18))
+    })
 
 });

--- a/test/lendingLogicAave.ts
+++ b/test/lendingLogicAave.ts
@@ -118,7 +118,7 @@ describe("LendingLogicAave", function() {
     })
 
     it("getAPRFromWrapped()", async() => {
-        const apr = await lendingLogic.getAPRFromUnderlying(aToken.address);
+        const apr = await lendingLogic.getAPRFromWrapped(aToken.address);
         expect(apr).to.eq(ethers.BigNumber.from("10").pow(16)) // one percent
     })
 

--- a/test/lendingLogicAave.ts
+++ b/test/lendingLogicAave.ts
@@ -34,7 +34,7 @@ describe("LendingLogicAave", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const aTokenFactory = new MockATokenFactory(signers[0]);
 
@@ -96,7 +96,7 @@ describe("LendingLogicAave", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]
@@ -108,5 +108,18 @@ describe("LendingLogicAave", function() {
         expect(tokenBalance).to.eq(mintAmount);
         expect(aTokenBalance).to.eq(0);
     });
+
+    it("getAPRFromUnderlying()", async() => {
+        const reserveData  = await lendingPool.getReserveData(token.address);
+        expect(reserveData.liquidityRate).to.eq(ethers.BigNumber.from("10").pow(25)) // one percent
+
+        const apr = await lendingLogic.getAPRFromUnderlying(token.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16)) // one percent
+    })
+
+    it("getAPRFromWrapped()", async() => {
+        const apr = await lendingLogic.getAPRFromUnderlying(aToken.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16)) // one percent
+    })
 
 });

--- a/test/lendingLogicAaveV2.ts
+++ b/test/lendingLogicAaveV2.ts
@@ -1,0 +1,138 @@
+import chai, {expect} from "chai";
+import { deployContract, solidity} from "ethereum-waffle";
+import { ethers, run, ethereum, network } from "@nomiclabs/buidler";
+import { Signer, constants } from "ethers";
+
+import LendingLogicAaveV2Artifact from "../artifacts/LendingLogicAaveV2.json";
+import MockAaveLendingPoolV2Artifact from "../artifacts/MockAaveLendingPoolV2.json";
+import { MockTokenFactory } from "../typechain/MockTokenFactory";
+import { MockATokenV2Factory } from "../typechain/MockATokenV2Factory"
+import { MockToken } from "../typechain/MockToken";
+import { MockATokenV2 } from "../typechain/MockATokenV2";
+import { LendingLogicAaveV2 } from "../typechain/LendingLogicAaveV2";
+import { MockAaveLendingPoolV2 } from "../typechain/MockAaveLendingPoolV2";
+
+import TimeTraveler from "../utils/TimeTraveler";
+import { parseEther } from "ethers/lib/utils";
+
+chai.use(solidity);
+
+const mintAmount = parseEther("1000000");
+
+describe("LendingLogicAaveV2", function() {
+    this.timeout(300000000);
+
+    let signers: Signer[];
+    let account;
+    let timeTraveler: TimeTraveler;
+    let lendingLogic: LendingLogicAaveV2;
+    let lendingPool: MockAaveLendingPoolV2;
+    let token: MockToken;
+    let aToken: MockATokenV2;
+
+    before(async() => {
+        signers = await ethers.getSigners();
+        account = await signers[0].getAddress();
+        timeTraveler = new TimeTraveler(ethereum);
+
+        const tokenFactory = new MockTokenFactory(signers[0]);
+        const aTokenFactory = new MockATokenV2Factory(signers[0]);
+
+        token = await tokenFactory.deploy("token", "token");
+        aToken = await aTokenFactory.deploy(token.address);
+
+        await token.mint(mintAmount, account);
+
+        lendingPool = await deployContract(signers[0], MockAaveLendingPoolV2Artifact, [token.address, aToken.address]) as MockAaveLendingPoolV2;
+        lendingLogic = await deployContract(signers[0], LendingLogicAaveV2Artifact,
+            [lendingPool.address, 0, account]) as LendingLogicAaveV2;
+
+        await timeTraveler.snapshot();
+    });
+
+    beforeEach(async() => {
+        await timeTraveler.revertSnapshot();
+    });
+
+    it("Deploying with lendingPool set to the zero address should fail", async() => {
+        const promise = deployContract(signers[0], LendingLogicAaveV2Artifact, [constants.AddressZero, 0, account]);
+        await expect(promise).to.be.revertedWith("LENDING_POOL_INVALID");
+    });
+
+    it("lend()", async() => {
+        const calls = await lendingLogic.lend(token.address, mintAmount);
+
+        expect(calls.targets.length).to.eq(3);
+        expect(calls.data.length).to.eq(3);
+
+        await signers[0].sendTransaction({
+            to: calls.targets[0],
+            data: calls.data[0]
+        });
+
+        await signers[0].sendTransaction({
+            to: calls.targets[1],
+            data: calls.data[1]
+        });
+
+        await signers[0].sendTransaction({
+            to: calls.targets[2],
+            data: calls.data[2]
+        });
+
+        const tokenBalance = await token.balanceOf(account);
+        const aTokenBalance = await aToken.balanceOf(account);
+
+        expect(tokenBalance).to.eq(0);
+        expect(aTokenBalance).to.eq(mintAmount);
+    });
+
+    it("unlend()", async() => {
+        await token.approve(lendingPool.address, constants.MaxUint256);
+        await lendingPool.deposit(token.address, mintAmount, account, 0);
+
+        expect(await aToken.balanceOf(account)).to.eq(mintAmount);
+
+        const calls = await lendingLogic.unlend(aToken.address, mintAmount);
+
+        expect(calls.targets.length).to.eq(1);
+        expect(calls.data.length).to.eq(1);
+
+        await signers[0].sendTransaction({
+            to: calls.targets[0],
+            data: calls.data[0]
+        })
+
+        const tokenBalance = await token.balanceOf(account);
+        const aTokenBalance = await aToken.balanceOf(account);
+
+        expect(tokenBalance).to.eq(mintAmount);
+        expect(aTokenBalance).to.eq(0);
+    });
+
+    it("getAPRFromUnderlying()", async() => {
+        const reserveData = await lendingPool.getReserveData(token.address);
+        expect(reserveData.currentLiquidityRate).to.eq(ethers.BigNumber.from("10").pow(25)) // one percent
+
+        const apr = await lendingLogic.getAPRFromUnderlying(token.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16)) // one percent
+    })
+
+    it("getAPRFromWrapped()", async() => {
+        const apr = await lendingLogic.getAPRFromWrapped(aToken.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16)) // one percent
+    })
+
+    it("exchangeRate()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRate(aToken.address);
+        // 1 wrapped = 1
+        expect(exchangeRate).to.eq( ethers.BigNumber.from("10").pow(18))
+    })
+
+    it("exchangeRateView()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRateView(aToken.address);
+        // 1 wrapped == 1
+        expect(exchangeRate).to.eq( ethers.BigNumber.from("10").pow(18))
+    })
+
+});

--- a/test/lendingLogicCompound.ts
+++ b/test/lendingLogicCompound.ts
@@ -22,6 +22,7 @@ chai.use(solidity);
 
 const mintAmount = parseEther("1000000");
 // keccak("Compound");
+const COMPOUND = "0x561ca898cce9f021c15a441ef41899706e923541cee724530075d1a1144761c7";
 const PLACEHOLDER_PROTOCOL = "0x561ca898cce9f021c15a441ef41899706e923541cee724530075d1a1144761c7";
 
 describe("LendingLogicCompound", function() {
@@ -39,7 +40,7 @@ describe("LendingLogicCompound", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const cTokenFactory = new MockCTokenFactory(signers[0]);
 
@@ -49,12 +50,12 @@ describe("LendingLogicCompound", function() {
         await token.mint(mintAmount, account);
 
         lendingRegistry = await (new LendingRegistryFactory(signers[0])).deploy();
-        lendingLogic = await deployContract(signers[0], LendingLogicCompoundArtifact, [lendingRegistry.address, PLACEHOLDER_PROTOCOL]) as LendingLogicCompound;
-        
+        lendingLogic = await deployContract(signers[0], LendingLogicCompoundArtifact, [lendingRegistry.address, COMPOUND]) as LendingLogicCompound;
+
         await lendingRegistry.setProtocolToLogic(PLACEHOLDER_PROTOCOL, lendingLogic.address);
         await lendingRegistry.setWrappedToProtocol(cToken.address, PLACEHOLDER_PROTOCOL);
         await lendingRegistry.setUnderlyingToProtocolWrapped(token.address, PLACEHOLDER_PROTOCOL, cToken.address);
-        
+
         await timeTraveler.snapshot();
     });
 
@@ -63,7 +64,10 @@ describe("LendingLogicCompound", function() {
     });
 
     it("Deploying with the lending registry to the zero address should fail", async() => {
-        const promise = deployContract(signers[0], LendingLogicCompoundArtifact, [constants.AddressZero, PLACEHOLDER_PROTOCOL]);
+        const promise = deployContract(signers[0], LendingLogicCompoundArtifact, [
+            constants.AddressZero,
+            COMPOUND
+        ]);
         await expect(promise).to.be.revertedWith("INVALID_LENDING_REGISTRY");
     });
 
@@ -105,7 +109,7 @@ describe("LendingLogicCompound", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]

--- a/test/lendingLogicCompound.ts
+++ b/test/lendingLogicCompound.ts
@@ -125,8 +125,8 @@ describe("LendingLogicCompound", function() {
 
     it("exchangeRateView()", async() => {
         const exchangeRate = await cToken.exchangeRateStored()
-        // 1 wrapped (8 decimals) = 0.02 (18 decimals)
-        expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(26).mul(2))
+        // 1 wrapped (8 decimals) = 0.2 (8 decimals)
+        expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(17).mul(2))
         const exchangeRateLending = await lendingLogic.exchangeRateView(cToken.address);
         expect(exchangeRate).to.eq(exchangeRateLending)
     })

--- a/test/lendingLogicCompound.ts
+++ b/test/lendingLogicCompound.ts
@@ -122,4 +122,24 @@ describe("LendingLogicCompound", function() {
         expect(cTokenBalance).to.eq(0);
     });
 
+    it("getAPRFromUnderlying()", async() => {
+        const supplyRate =  await cToken.supplyRatePerBlock();
+        expect(supplyRate).to.eq(20000000000);
+
+        await lendingLogic.setBlocksPerYear(2000000)
+
+        const apr = await lendingLogic.getAPRFromUnderlying(token.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16).mul(4)) // 4 percent
+    })
+
+    it("getAPRFromWrapped()", async() => {
+        const supplyRate =  await cToken.supplyRatePerBlock();
+        expect(supplyRate).to.eq(20000000000);
+
+        await lendingLogic.setBlocksPerYear(2000000)
+
+        const apr = await lendingLogic.getAPRFromWrapped(cToken.address);
+        expect(apr).to.eq(ethers.BigNumber.from("10").pow(16).mul(4)) // 4 percent
+    })
+
 });

--- a/test/lendingLogicCompound.ts
+++ b/test/lendingLogicCompound.ts
@@ -118,14 +118,12 @@ describe("LendingLogicCompound", function() {
         expect(cTokenBalance).to.eq(0);
     });
 
-    it.only("exchangeRate()", async() => {
-        const exchangeRate = await cToken.exchangeRate()
-        // 1 wrapped (8 decimals) = 0.02 (18 decimals)
-        expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(26).mul(2))
+    it("exchangeRate()", async() => {
+        await cToken.exchangeRateCurrent()
         await lendingLogic.exchangeRate(cToken.address);
     })
 
-    it.only("exchangeRateView()", async() => {
+    it("exchangeRateView()", async() => {
         const exchangeRate = await cToken.exchangeRateStored()
         // 1 wrapped (8 decimals) = 0.02 (18 decimals)
         expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(26).mul(2))

--- a/test/stakingLogicSushi.ts
+++ b/test/stakingLogicSushi.ts
@@ -39,7 +39,7 @@ describe("StakingLogicSushi", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const xSUSHIFactory = new MockXSushiFactory(signers[0]);
 
@@ -50,11 +50,11 @@ describe("StakingLogicSushi", function() {
 
         lendingRegistry = await (new LendingRegistryFactory(signers[0])).deploy();
         lendingLogic = await deployContract(signers[0], StakingLogicSushiArtifact, [lendingRegistry.address, PLACEHOLDER_PROTOCOL]) as StakingLogicSushi;
-        
+
         await lendingRegistry.setProtocolToLogic(PLACEHOLDER_PROTOCOL, lendingLogic.address);
         await lendingRegistry.setWrappedToProtocol(xSUSHI.address, PLACEHOLDER_PROTOCOL);
         await lendingRegistry.setUnderlyingToProtocolWrapped(token.address, PLACEHOLDER_PROTOCOL, xSUSHI.address);
-        
+
         await timeTraveler.snapshot();
     });
 
@@ -105,7 +105,7 @@ describe("StakingLogicSushi", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]

--- a/test/stakingLogicSushi.ts
+++ b/test/stakingLogicSushi.ts
@@ -118,4 +118,14 @@ describe("StakingLogicSushi", function() {
         expect(xSUSHIBalance).to.eq(0);
     });
 
+    it("getAPRFromUnderlying()", async() => {
+        const apr = await lendingLogic.getAPRFromUnderlying(token.address);
+        expect(apr).to.eq(ethers.BigNumber.from("2").pow(256).sub(1))
+    })
+
+    it("getAPRFromWrapped()", async() => {
+        const apr = await lendingLogic.getAPRFromWrapped(xSUSHI.address);
+        expect(apr).to.eq(ethers.BigNumber.from("2").pow(256).sub(1))
+    })
+
 });

--- a/test/stakingLogicSushi.ts
+++ b/test/stakingLogicSushi.ts
@@ -39,7 +39,7 @@ describe("StakingLogicSushi", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const xSUSHIFactory = new MockXSushiFactory(signers[0]);
 
@@ -50,11 +50,12 @@ describe("StakingLogicSushi", function() {
 
         lendingRegistry = await (new LendingRegistryFactory(signers[0])).deploy();
         lendingLogic = await deployContract(signers[0], StakingLogicSushiArtifact, [lendingRegistry.address, PLACEHOLDER_PROTOCOL]) as StakingLogicSushi;
-        
+
         await lendingRegistry.setProtocolToLogic(PLACEHOLDER_PROTOCOL, lendingLogic.address);
         await lendingRegistry.setWrappedToProtocol(xSUSHI.address, PLACEHOLDER_PROTOCOL);
+        await lendingRegistry.setWrappedToUnderlying(xSUSHI.address, token.address);
         await lendingRegistry.setUnderlyingToProtocolWrapped(token.address, PLACEHOLDER_PROTOCOL, xSUSHI.address);
-        
+
         await timeTraveler.snapshot();
     });
 
@@ -105,7 +106,7 @@ describe("StakingLogicSushi", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]
@@ -117,5 +118,21 @@ describe("StakingLogicSushi", function() {
         expect(tokenBalance).to.eq(mintAmount);
         expect(xSUSHIBalance).to.eq(0);
     });
+
+    it("exchangeRate()", async() => {
+        await token.approve(xSUSHI.address, constants.MaxUint256);
+        await xSUSHI["mint(uint256)"](mintAmount);
+
+        await lendingLogic.exchangeRate(xSUSHI.address)
+    })
+
+    it("exchangeRateView()", async() => {
+        await token.approve(xSUSHI.address, constants.MaxUint256);
+        await xSUSHI["mint(uint256)"](mintAmount);
+
+        const exchangeRate = await lendingLogic.exchangeRateView(xSUSHI.address);
+        // 1 xToken = 0.2
+        expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(16).mul(20))
+    })
 
 });

--- a/test/stakingLogicYVault.ts
+++ b/test/stakingLogicYVault.ts
@@ -39,7 +39,7 @@ describe("StakingLogicYGov", function() {
         signers = await ethers.getSigners();
         account = await signers[0].getAddress();
         timeTraveler = new TimeTraveler(ethereum);
-        
+
         const tokenFactory = new MockTokenFactory(signers[0]);
         const yGOVFactory = new MockYVaultFactory(signers[0]);
 
@@ -50,11 +50,11 @@ describe("StakingLogicYGov", function() {
 
         lendingRegistry = await (new LendingRegistryFactory(signers[0])).deploy();
         lendingLogic = await deployContract(signers[0], StakingLogicYGovArtifact, [lendingRegistry.address, PLACEHOLDER_PROTOCOL]) as StakingLogicYGov;
-        
+
         await lendingRegistry.setProtocolToLogic(PLACEHOLDER_PROTOCOL, lendingLogic.address);
         await lendingRegistry.setWrappedToProtocol(yGov.address, PLACEHOLDER_PROTOCOL);
         await lendingRegistry.setUnderlyingToProtocolWrapped(token.address, PLACEHOLDER_PROTOCOL, yGov.address);
-        
+
         await timeTraveler.snapshot();
     });
 
@@ -105,7 +105,7 @@ describe("StakingLogicYGov", function() {
 
         expect(calls.targets.length).to.eq(1);
         expect(calls.data.length).to.eq(1);
-        
+
         await signers[0].sendTransaction({
             to: calls.targets[0],
             data: calls.data[0]
@@ -117,5 +117,17 @@ describe("StakingLogicYGov", function() {
         expect(tokenBalance).to.eq(mintAmount);
         expect(yGovBalance).to.eq(0);
     });
+
+    it("exchangeRate()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRate(yGov.address);
+        // 1 wrapped = 0.2
+        expect(exchangeRate).to.eq(ethers.BigNumber.from("10").pow(16).mul(20))
+    })
+
+    it("exchangeRateView()", async() => {
+        const exchangeRate = await lendingLogic.exchangeRateView(yGov.address);
+        // 1 wrapped == 0.2
+        expect(exchangeRate).to.eq( ethers.BigNumber.from("10").pow(16).mul(20))
+    })
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3106,9 +3106,9 @@ detect-port@^1.3.0:
     address "^1.0.1"
     debug "^2.6.0"
 
-"diamond-2@https://github.com/pie-dao/diamond-2.git/#ca94c95bbea06bbd961d525e06792bcec02c4462":
+"diamond-2@https://github.com/pie-dao/initialisable-diamond.git#ca94c95bbea06bbd961d525e06792bcec02c4462":
   version "1.3.3"
-  resolved "https://github.com/pie-dao/diamond-2.git/#ca94c95bbea06bbd961d525e06792bcec02c4462"
+  resolved "https://github.com/pie-dao/initialisable-diamond.git#ca94c95bbea06bbd961d525e06792bcec02c4462"
   dependencies:
     truffle "^5.1.44"
 


### PR DESCRIPTION
Includes #17 (https://github.com/pie-dao/ExperiPie/tree/feature/view-apr)
Includes #18 (https://github.com/pie-dao/ExperiPie/tree/feature/exchange-rate-getters)

I started working from `view-apr`, merged `exchange-rate-getters` into it, created the aave-v2 changes on top.



Implementing #19 